### PR TITLE
mention not triggered when skipped to next line.

### DIFF
--- a/lib/src/mention_tag_text_editing_controller.dart
+++ b/lib/src/mention_tag_text_editing_controller.dart
@@ -171,6 +171,7 @@ class MentionTagTextEditingController extends TextEditingController {
     final indexMentionStartSymbol = indexMentionStart - 1;
     if (indexMentionStartSymbol == 0) return true;
     if (mentionTagDecoration.allowEmbedding) return true;
+    if (value[indexMentionStartSymbol - 1] == '\n') return true;
     if (value[indexMentionStartSymbol - 1] == Constants.mentionEscape) {
       return true;
     }


### PR DESCRIPTION
steps to reproduce the issue.

run the example code provided in this package.
inside text field, add these properties.

  keyboardType: TextInputType.multiline,
  minLines: 1,
  maxLines: 5,

Now, skip to next line without writing anything on the keyboard(press Enter if on Emulator).
you can see that upon entering the trigger char(@), the onMention function would return the value null.